### PR TITLE
[UI Improvement] More intuitive way to call notifications

### DIFF
--- a/AppDevAnnouncements/Classes/NotificationViewController.swift
+++ b/AppDevAnnouncements/Classes/NotificationViewController.swift
@@ -8,26 +8,21 @@
 
 import UIKit
 
-public protocol NotificationDelegate: class {
-    func present(_ notificationViewController: NotificationViewController)
-}
-
-public class NotificationViewController: UIViewController {
+fileprivate class NotificationViewController: UIViewController {
 
     /// Components
     private var notificationView: NotificationView!
 
     /// Initializer variables
     private var announcement: Announcement
-    private weak var delegate : NotificationDelegate?
 
-    public init(announcement: Announcement, delegate: NotificationDelegate) {
+    fileprivate init(announcement: Announcement) {
         self.announcement = announcement
-        self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
+        self.modalPresentationStyle = .overFullScreen // Will eventually be changed to a custom presentation animation
     }
 
-    override public func viewDidLoad() {
+    override fileprivate func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
 
@@ -37,7 +32,6 @@ public class NotificationViewController: UIViewController {
         view.addSubview(notificationView)
 
         setupConstraints()
-        presentNotification()
     }
 
     private func setupConstraints() {
@@ -46,12 +40,6 @@ public class NotificationViewController: UIViewController {
             make.height.equalTo(notificationView.getTotalHeight(announcement))
             make.width.equalTo(NotificationView.Constants.notificationViewWidth)
         }
-    }
-
-    private func presentNotification() {
-        // TODO: Add backend logic later on
-        modalPresentationStyle = .overFullScreen
-        delegate?.present(self)
     }
 
     @objc private func dismissNotification() {
@@ -69,4 +57,11 @@ public class NotificationViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+}
+
+public extension UIViewController {
+    func presentNotification(announcement: Announcement) {
+        let notification = NotificationViewController(announcement: announcement)
+        present(notification, animated: true)
+    }
 }

--- a/AppDevAnnouncements/Classes/NotificationViewController.swift
+++ b/AppDevAnnouncements/Classes/NotificationViewController.swift
@@ -11,18 +11,18 @@ import UIKit
 fileprivate class NotificationViewController: UIViewController {
 
     /// Components
-    private var notificationView: NotificationView!
+    var notificationView: NotificationView!
 
     /// Initializer variables
-    private var announcement: Announcement
+    var announcement: Announcement
 
-    fileprivate init(announcement: Announcement) {
+    init(announcement: Announcement) {
         self.announcement = announcement
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .overFullScreen // Will eventually be changed to a custom presentation animation
     }
 
-    override fileprivate func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
 
@@ -34,7 +34,7 @@ fileprivate class NotificationViewController: UIViewController {
         setupConstraints()
     }
 
-    private func setupConstraints() {
+    func setupConstraints() {
         notificationView.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.height.equalTo(notificationView.getTotalHeight(announcement))
@@ -42,13 +42,13 @@ fileprivate class NotificationViewController: UIViewController {
         }
     }
 
-    @objc private func dismissNotification() {
+    @objc func dismissNotification() {
         dismiss(animated: true, completion: nil)
     }
 
     /// Executes the CTA. The currently supported CTAs are:
     /// - URLs
-    @objc private func performCTA() {
+    @objc func performCTA() {
         guard let url = URL(string: announcement.ctaAction) else { return }
         UIApplication.shared.open(url)
     }
@@ -58,6 +58,8 @@ fileprivate class NotificationViewController: UIViewController {
     }
 
 }
+
+// MARK: - UIViewController+Extension for notification presentation
 
 public extension UIViewController {
     func presentNotification(announcement: Announcement) {

--- a/AppDevAnnouncements/Classes/Utils.swift
+++ b/AppDevAnnouncements/Classes/Utils.swift
@@ -3,7 +3,7 @@
 //  TestEnv
 //
 //  Created by Kevin Chan on 10/27/19.
-//  Copyright © 2019 Gonzalo Gonzalez. All rights reserved.
+//  Copyright © 2019 Cornell AppDev. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
## Overview

Changes adding a notification to the subview to have it presented (unintuitive) to having a notification presented using `presentNotification()` (more intuitive). On top of being more intuitive, we have reduced the lines of code from 3 lines and an extension to a whopping 2 lines with no extension (create the Announcement and pass it into the present function).




## Changes Made

I removed all the delegation code and replaced it with a UIViewController extension with the function `presentNotification()` that takes in a user created Announcement object to present a notification. With this change, the extension was made public and the NotificationViewController class was able to be better secured by making it fileprivate (so the extension can access it's initializer).

## Test Coverage

The difference between creating a notification before and after this PR...

<details>
<summary>[PRE-PR] Show with Image</summary>

```
let announcement = Announcement(imageUrl: "pollo", subject: "Download Pollo", body: "Check out Cornell AppDev’s newest app, Pollo! Eliminating the need for expensive clickers, Pollo enables users to easily create and participate in polls.", ctaText: "Download", ctaAction: "https://givingday.cornell.edu/campaigns/cu-app-development")
let notification = NotificationViewController(announcement: announcement, delegate: self)
view.addSubview(notification.view)
```
</details>

<details>
<summary>[POST-PR] Show with Image</summary>

```
let announcement = Announcement(imageUrl: "pollo", subject: "Download Pollo", body: "Check out Cornell AppDev’s newest app, Pollo! Eliminating the need for expensive clickers, Pollo enables users to easily create and participate in polls.", ctaText: "Download", ctaAction: "https://givingday.cornell.edu/campaigns/cu-app-development")
presentNotification(announcement: announcement)
```
</details>

## Related PRs or Issues

#8